### PR TITLE
Allow id-token write in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - "v*"
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change adds `id-token: write` to the permissions section.