### PR TITLE
Allow attestations write in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  attestations: write
 
 jobs:
   release:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change adds the `attestations: write` permission to the workflow.